### PR TITLE
Update mods.toml

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -28,7 +28,7 @@ ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.i18nupdatemod]]
-modId = "cloth_config"
+modId = "cloth-config"
 mandatory = true
 versionRange = "[4,)"
 ordering = "NONE"


### PR DESCRIPTION
1.16.5 的 cloth config 的 modid 错了
-----------
![image](https://user-images.githubusercontent.com/106016532/212134687-78e9150f-909c-4fcd-b814-71118cd569aa.png)
